### PR TITLE
Update params.cpp

### DIFF
--- a/planner_common/src/params.cpp
+++ b/planner_common/src/params.cpp
@@ -844,6 +844,7 @@ bool MBParams::loadParams(std::string ns) {
     str_tmp += exp_sensor_list[i] + ", ";
   }
   ROSPARAM_INFO(str_tmp);
+  return true;
 }
 
 bool RobotDynamicsParams::loadParams(std::string ns) {


### PR DESCRIPTION
Otherwise, an error occurs

The output of GDB and error from terminal:

```shell
free(): double free detected in tcache 2
mbplanner_node received signal SIGABRT, Aborted.
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007ffff66d27f1 in __GI_abort () at abort.c:79
#2  0x00007ffff671b837 in __libc_message (action=action@entry=do_abort, 
    fmt=fmt@entry=0x7ffff6848a7b "%s\n") at ../sysdeps/posix/libc_fatal.c:181
#3  0x00007ffff67228ba in malloc_printerr (
    str=str@entry=0x7ffff684a6e8 "free(): double free detected in tcache 2")
    at malloc.c:5342
#4  0x00007ffff672a0ed in _int_free (have_lock=0, p=0x555555ba7660, 
    av=0x7ffff6a7dc40 <main_arena>) at malloc.c:4195
#5  __GI___libc_free (mem=0x555555ba7670) at malloc.c:3134
#6  0x00007ffff7b75606 in explorer::MBParams::loadParams(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) [clone .cold] ()
   from /home/mason/ws/sota_ws/devel/lib/libplanner_common.so
#7  0x00007ffff70daebc in explorer::mbplanner::MBTree::MBTree(ros::NodeHandle const&, ros::NodeHandle const&) () from /home/mason/ws/sota_ws/devel/lib/libmbplanner.so
#8  0x00007ffff70c9384 in explorer::MBPlanner::MBPlanner(ros::NodeHandle const&, ros::NodeHandle const&) () from /home/mason/ws/sota_ws/devel/lib/libmbplanner.so
#9  0x000055555555c16e in main ()
```